### PR TITLE
Fix potential security problem from dependency

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -183,7 +183,7 @@
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
                 "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "version": "==3.13"
+            "version": "==4.2b1"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
GitHub gave an alert to `pyyaml` being able to create potential security problem from the `Pipfile.lock` file. This should update the version of `pyyaml` being used to what it was recommended that the oldest version at most that should be used.